### PR TITLE
Replace link to unreachable remergr.io with another project

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This has become unusable due to `webtask` shutting down the script. See alternative solutions:
 
 1. [Native Github Support](https://github.com/blog/2243-rebase-and-merge-pull-requests)
-2. [Remergr.io](http://remergr.io) ***free*** *for open source projects*
+2. [Autorebase](https://github.com/tibdex/autorebase)
 
 ## What❓
 


### PR DESCRIPTION
I stumbled into this repo while I was doing some research before working on [Autorebase](https://github.com/tibdex/autorebase). I clicked on the link to remergr.io but it has become unreachable. I'm proposing replacing the link to a one pointing to https://github.com/tibdex/autorebase. This can be seen as a shameless but I believe Autorebase is close to the original goals of this project.

Feel free to merge or close ;)